### PR TITLE
No need to transmute an enum to a u8, it can be directly cast with "as"

### DIFF
--- a/codec/src/codec/encode.rs
+++ b/codec/src/codec/encode.rs
@@ -106,7 +106,7 @@ fn write_content(packet: &Packet, dst: &mut BytesMut) {
                         flags |= ConnectFlags::WILL_RETAIN;
                     }
 
-                    let b: u8 = qos.into();
+                    let b: u8 = qos as u8;
 
                     flags |= ConnectFlags::from_bits_truncate(b << WILL_QOS_SHIFT);
                 }
@@ -147,7 +147,7 @@ fn write_content(packet: &Packet, dst: &mut BytesMut) {
         } => {
             dst.put_slice(&[
                 if session_present { 0x01 } else { 0x00 },
-                return_code.into(),
+                return_code as u8,
             ]);
         }
 
@@ -183,7 +183,7 @@ fn write_content(packet: &Packet, dst: &mut BytesMut) {
 
             for &(ref filter, qos) in topic_filters {
                 write_slice(filter.as_ref(), dst);
-                dst.put_slice(&[qos.into()]);
+                dst.put_slice(&[qos as u8]);
             }
         }
 
@@ -197,7 +197,7 @@ fn write_content(packet: &Packet, dst: &mut BytesMut) {
                 .iter()
                 .map(|s| {
                     if let SubscribeReturnCode::Success(qos) = *s {
-                        qos.into()
+                        qos as u8
                     } else {
                         0x80
                     }

--- a/codec/src/packet.rs
+++ b/codec/src/packet.rs
@@ -200,7 +200,7 @@ impl Packet {
             Packet::Publish(Publish {
                 dup, qos, retain, ..
             }) => {
-                let mut b = qos.into();
+                let mut b = qos as u8;
 
                 b <<= 1;
 

--- a/codec/src/proto.rs
+++ b/codec/src/proto.rs
@@ -6,12 +6,6 @@ macro_rules! const_enum {
                 unsafe { ::std::mem::transmute(u) }
             }
         }
-
-        impl ::std::convert::Into<$repr> for $name {
-            fn into(self) -> $repr {
-                unsafe { ::std::mem::transmute(self) }
-            }
-        }
     };
 }
 


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>