### PR TITLE
Elimninate std::io::Cursor use

### DIFF
--- a/codec/src/codec/encode.rs
+++ b/codec/src/codec/encode.rs
@@ -145,10 +145,7 @@ fn write_content(packet: &Packet, dst: &mut BytesMut) {
             session_present,
             return_code,
         } => {
-            dst.put_slice(&[
-                if session_present { 0x01 } else { 0x00 },
-                return_code as u8,
-            ]);
+            dst.put_slice(&[if session_present { 0x01 } else { 0x00 }, return_code as u8]);
         }
 
         Packet::Publish(Publish {

--- a/codec/src/codec/mod.rs
+++ b/codec/src/codec/mod.rs
@@ -1,5 +1,3 @@
-use std::io::Cursor;
-
 use actix_codec::{Decoder, Encoder};
 use bytes::BytesMut;
 
@@ -110,8 +108,7 @@ impl Decoder for Codec {
                         return Ok(None);
                     }
                     let packet_buf = src.split_to(fixed.remaining_length);
-                    let mut packet_cur = Cursor::new(packet_buf.freeze());
-                    let packet = read_packet(&mut packet_cur, fixed)?;
+                    let packet = read_packet(packet_buf.freeze(), fixed)?;
                     self.state = DecodeState::FrameHeader;
                     src.reserve(2);
                     return Ok(Some(packet));


### PR DESCRIPTION
Parts of this change was taken and adapted from the v5 branch to
break down the changes down into smaller chunks.

Signed-off-by: Daniel Egger <daniel.egger@axiros.com>