### PR TITLE
Change packet_id to std::num::NonZeroU16

### DIFF
--- a/codec/src/error.rs
+++ b/codec/src/error.rs
@@ -4,6 +4,7 @@ use std::{io, str};
 pub enum ParseError {
     InvalidProtocol,
     InvalidLength,
+    MalformedPacket,
     UnsupportedProtocolLevel,
     ConnectReservedFlagSet,
     ConnAckReservedFlagSet,
@@ -24,6 +25,10 @@ impl PartialEq for ParseError {
             },
             ParseError::InvalidLength => match other {
                 ParseError::InvalidLength => true,
+                _ => false,
+            },
+            ParseError::MalformedPacket => match other {
+                ParseError::MalformedPacket => true,
                 _ => false,
             },
             ParseError::UnsupportedProtocolLevel => match other {

--- a/codec/src/packet.rs
+++ b/codec/src/packet.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use bytestring::ByteString;
+use std::num::NonZeroU16;
 
 use crate::proto::{Protocol, QoS};
 
@@ -86,7 +87,7 @@ pub struct Publish {
     /// the information channel to which payload data is published.
     pub topic: ByteString,
     /// only present in PUBLISH Packets where the QoS level is 1 or 2.
-    pub packet_id: Option<u16>,
+    pub packet_id: Option<NonZeroU16>,
     /// the Application Message that is being published.
     pub payload: Bytes,
 }
@@ -118,34 +119,34 @@ pub enum Packet {
     /// Publish acknowledgment
     PublishAck {
         /// Packet Identifier
-        packet_id: u16,
+        packet_id: NonZeroU16,
     },
     /// Publish received (assured delivery part 1)
     PublishReceived {
         /// Packet Identifier
-        packet_id: u16,
+        packet_id: NonZeroU16,
     },
     /// Publish release (assured delivery part 2)
     PublishRelease {
         /// Packet Identifier
-        packet_id: u16,
+        packet_id: NonZeroU16,
     },
     /// Publish complete (assured delivery part 3)
     PublishComplete {
         /// Packet Identifier
-        packet_id: u16,
+        packet_id: NonZeroU16,
     },
 
     /// Client subscribe request
     Subscribe {
         /// Packet Identifier
-        packet_id: u16,
+        packet_id: NonZeroU16,
         /// the list of Topic Filters and QoS to which the Client wants to subscribe.
         topic_filters: Vec<(ByteString, QoS)>,
     },
     /// Subscribe acknowledgment
     SubscribeAck {
-        packet_id: u16,
+        packet_id: NonZeroU16,
         /// corresponds to a Topic Filter in the SUBSCRIBE Packet being acknowledged.
         status: Vec<SubscribeReturnCode>,
     },
@@ -153,14 +154,14 @@ pub enum Packet {
     /// Unsubscribe request
     Unsubscribe {
         /// Packet Identifier
-        packet_id: u16,
+        packet_id: NonZeroU16,
         /// the list of Topic Filters that the Client wishes to unsubscribe from.
         topic_filters: Vec<ByteString>,
     },
     /// Unsubscribe acknowledgment
     UnsubscribeAck {
         /// Packet Identifier
-        packet_id: u16,
+        packet_id: NonZeroU16,
     },
 
     /// PING request

--- a/src/client.rs
+++ b/src/client.rs
@@ -282,7 +282,7 @@ where
                 p => Err(MqttError::Unexpected(p, "Expected CONNECT-ACK packet")),
             }
         }
-            .boxed_local()
+        .boxed_local()
     }
 }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::marker::PhantomData;
+use std::num::NonZeroU16;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
@@ -237,7 +238,7 @@ where
 pub(crate) struct PublishResponse<T, E> {
     #[pin]
     fut: T,
-    packet_id: Option<u16>,
+    packet_id: Option<NonZeroU16>,
     _t: PhantomData<E>,
 }
 
@@ -264,7 +265,7 @@ where
 /// Subscribe service response future
 pub(crate) struct SubscribeResponse<E> {
     fut: LocalBoxFuture<'static, Result<SubscribeResult, E>>,
-    packet_id: u16,
+    packet_id: NonZeroU16,
 }
 
 impl<E> Future for SubscribeResponse<E> {

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::num::NonZeroU16;
 
 use actix_router::Path;
 use bytes::Bytes;
@@ -82,7 +83,7 @@ impl<S> Publish<S> {
 
     #[inline]
     /// only present in PUBLISH Packets where the QoS level is 1 or 2.
-    pub fn id(&self) -> Option<u16> {
+    pub fn id(&self) -> Option<NonZeroU16> {
         self.publish.packet_id
     }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::fmt;
+use std::num::NonZeroU16;
 
 use actix_ioframe::Sink;
 use actix_utils::oneshot;
@@ -71,7 +72,7 @@ impl MqttSink {
             dup,
             retain: false,
             qos: mqtt::QoS::AtLeastOnce,
-            packet_id: Some(inner.idx),
+            packet_id: NonZeroU16::new(inner.idx),
         });
         log::trace!("Publish (QoS1) to {:#?}", publish);
 
@@ -79,9 +80,9 @@ impl MqttSink {
         rx.map_err(|_| ())
     }
 
-    pub(crate) fn complete_publish_qos1(&mut self, packet_id: u16) {
+    pub(crate) fn complete_publish_qos1(&mut self, packet_id: NonZeroU16) {
         if let Some((idx, tx)) = self.inner.get_mut().queue.pop_front() {
-            if idx != packet_id {
+            if idx != packet_id.get() {
                 log::trace!(
                     "MQTT protocol error, packet_id order does not match, expected {}, got: {}",
                     idx,


### PR DESCRIPTION
Again this change (based on top of #6) is broken out of (and shamelessly
copies parts of the parsing code from Max Gortman
<mgortman@microsoft.com>) the v5 branch.

Signed-off-by: Daniel Egger <daniel.egger@axiros.com>